### PR TITLE
fix: recall unavailable

### DIFF
--- a/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiAdminPlugin.kt
+++ b/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiAdminPlugin.kt
@@ -40,6 +40,7 @@ public object MiraiAdminPlugin : KotlinPlugin(
         MiraiAdministrator.registerTo(globalEventChannel())
 
         if (ComparableService<MessageSourceHandler>().isEmpty()) {
+            ComparableService.instances.add(MiraiMessageRecorder)
             MiraiMessageRecorder.registerTo(globalEventChannel())
         }
 

--- a/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiService.kt
+++ b/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiService.kt
@@ -90,9 +90,6 @@ internal fun ComparableService.Loader.reload() {
     instances.add(MiraiMemberCleaner)
     instances.add(MiraiCurfewTimer)
     instances.add(MiraiContentCensor)
-    if (invoke<MessageSourceHandler>().isEmpty()) {
-        instances.add(MiraiMessageRecorder)
-    }
 }
 
 internal fun ComparableService.Loader.render(): String = buildString {


### PR DESCRIPTION
```
ComparableService.reload()
执行之后
ComparableService<MessageSourceHandler>().isEmpty()
永远为false
MiraiMessageRecorder.registerTo(globalEventChannel())
默认消息记录永远无法注册，撤回消息便不可用

将在无MessageSourceHandler时添加并注册默认实现
```