### PR TITLE
fix:recall QuoteReply msg

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@
 1. 不指定`contact`时，可以通过**回复消息**指定要撤销的消息，如果没有指定，将尝试撤销最后一条不是由指令发送者发送的消息
 2. `contact`是群员时，将尝试撤销这个群员的最后一条消息
 3. `contact`是群或好友时，将尝试撤销bot的最后一条消息
+###### Tips: 不通过 *回复消息* 撤销时，可撤销消息范围受`AdminSetting.yml`的`record_limit`限制
 
 ## AdminRegisteredCommand
 

--- a/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiAdministrator.kt
+++ b/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiAdministrator.kt
@@ -157,7 +157,7 @@ public object MiraiAdministrator : SimpleListenerHost() {
 
     // XXX: AdminContactCommand ...
     @EventHandler
-    internal suspend fun MessageEvent.approve() {
+    internal suspend fun FriendMessageEvent.approve() {
         if (toCommandSender().hasPermission(AdminContactCommand.permission).not()) return
         val original = (source(contact = null, event = this) ?: message.findIsInstance<QuoteReply>()?.source ?: return)
             .originalMessage

--- a/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiMessageRecorder.kt
+++ b/src/main/kotlin/xyz/cssxsh/mirai/plugin/MiraiMessageRecorder.kt
@@ -41,14 +41,14 @@ internal object MiraiMessageRecorder : SimpleListenerHost(), MessageSourceHandle
                 record = records[contact.group.id] ?: return null
                 record.findLast { it.fromId == contact.id }
             }
-            contact != null -> {
-                record = records[contact.id] ?: return null
-                record.findLast { it.fromId == contact.bot.id }
-            }
             event != null -> {
                 record = records[event.subject.id] ?: ArrayList()
                 event.message.findIsInstance<QuoteReply>()?.source
                     ?: record.findLast { it.fromId != event.source.fromId }
+            }
+            contact != null -> {
+                record = records[contact.id] ?: return null
+                record.findLast { it.fromId == contact.bot.id }
             }
             else -> throw IllegalArgumentException("无法指定要撤回消息")
         } ?: return null


### PR DESCRIPTION
1. 群内通过回复撤销消息时，会自动@人员，原有代码会一直撤销指定人消息
2. 缩小处理自动申请的时间范围（事件只会发送给owner,监听好友消息即可）
3. 更新文档